### PR TITLE
Scaffold FastAPI service with Poetry

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+ENV POETRY_VERSION=1.7.1 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "poetry==${POETRY_VERSION}"
+
+COPY pyproject.toml ./
+RUN poetry install --no-interaction --no-ansi --no-root
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -1,0 +1,9 @@
+[alembic]
+script_location = app/db/migrations
+prepend_sys_path = .
+
+sqlalchemy.url = sqlite:///./app.db
+
+dialect_name = sqlite
+
+offset = 0

--- a/services/api/app/__init__.py
+++ b/services/api/app/__init__.py
@@ -1,0 +1,5 @@
+"""ai-pm API application package."""
+
+from app.main import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/services/api/app/api/__init__.py
+++ b/services/api/app/api/__init__.py
@@ -1,0 +1,10 @@
+"""API router configuration."""
+
+from fastapi import APIRouter
+
+from app.api.v1 import router as v1_router
+
+api_router = APIRouter()
+api_router.include_router(v1_router, prefix="/v1", tags=["v1"])
+
+__all__ = ["api_router"]

--- a/services/api/app/api/v1/__init__.py
+++ b/services/api/app/api/v1/__init__.py
@@ -1,0 +1,10 @@
+"""Version 1 of the public API."""
+
+from fastapi import APIRouter
+
+from app.api.v1 import health
+
+router = APIRouter()
+router.include_router(health.router, tags=["health"])
+
+__all__ = ["router"]

--- a/services/api/app/api/v1/health.py
+++ b/services/api/app/api/v1/health.py
@@ -1,0 +1,11 @@
+"""Health check endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/ping")
+def ping() -> dict[str, str]:
+    """Simple heartbeat endpoint for monitoring."""
+    return {"status": "ok"}

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -1,0 +1,21 @@
+"""Application configuration powered by Pydantic settings."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Central application settings loaded from the environment."""
+
+    database_url: str = Field(
+        default="sqlite:///./app.db",
+        alias="DATABASE_URL",
+        description="Database connection string.",
+    )
+    otel_exporter_otlp_endpoint: str | None = Field(
+        default=None,
+        alias="OTEL_EXPORTER_OTLP_ENDPOINT",
+        description="Endpoint for OTLP trace exporter.",
+    )
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")

--- a/services/api/app/db/__init__.py
+++ b/services/api/app/db/__init__.py
@@ -1,0 +1,6 @@
+"""Database utilities package."""
+
+from app.db.base import SessionLocal, engine, get_session
+from app.db import models
+
+__all__ = ["engine", "SessionLocal", "get_session", "models"]

--- a/services/api/app/db/base.py
+++ b/services/api/app/db/base.py
@@ -1,0 +1,25 @@
+"""Database engine and session configuration."""
+
+from collections.abc import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import Settings
+
+_settings = Settings()
+
+engine = create_engine(_settings.database_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def get_session() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+__all__ = ["engine", "SessionLocal", "get_session"]

--- a/services/api/app/db/migrations/__init__.py
+++ b/services/api/app/db/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic migration package."""

--- a/services/api/app/db/migrations/env.py
+++ b/services/api/app/db/migrations/env.py
@@ -1,0 +1,58 @@
+"""Alembic environment configuration."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.config import Settings
+from app.db.models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+
+def get_url() -> str:
+    settings = Settings()
+    return settings.database_url
+
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    context.configure(
+        url=get_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        {"sqlalchemy.url": get_url()},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/api/app/db/migrations/script.py.mako
+++ b/services/api/app/db/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""Mako template for new Alembic migrations."""
+
+<%text>
+"""${message}"""
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass
+</%text>

--- a/services/api/app/db/migrations/versions/0001_initial.py
+++ b/services/api/app/db/migrations/versions/0001_initial.py
@@ -1,0 +1,20 @@
+"""Initial empty migration."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Initial upgrade step."""
+
+
+def downgrade() -> None:
+    """Initial downgrade step."""

--- a/services/api/app/db/migrations/versions/__init__.py
+++ b/services/api/app/db/migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Migration versions package."""

--- a/services/api/app/db/models.py
+++ b/services/api/app/db/models.py
@@ -1,0 +1,34 @@
+"""SQLAlchemy models."""
+
+from typing import Optional
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for ORM models."""
+
+
+class Organization(Base):
+    """Placeholder organization model."""
+
+    __tablename__ = "organizations"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    users: Mapped[list["User"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
+
+
+class User(Base):
+    """Placeholder user model."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    organization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("organizations.id"), nullable=True)
+    organization: Mapped[Optional[Organization]] = relationship(back_populates="users")
+
+
+__all__ = ["Base", "Organization", "User"]

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,0 +1,26 @@
+"""Application entrypoint for the ai-pm API service."""
+
+from fastapi import FastAPI
+
+from app.api import api_router
+from app.config import Settings
+from app.telemetry.otel import configure_telemetry
+
+
+def create_app() -> FastAPI:
+    """Create and configure a FastAPI application instance."""
+    settings = Settings()
+    application = FastAPI(title="ai-pm API", version="0.1.0")
+
+    configure_telemetry(application, settings)
+
+    @application.get("/healthz", tags=["health"])
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    application.include_router(api_router)
+
+    return application
+
+
+app = create_app()

--- a/services/api/app/telemetry/__init__.py
+++ b/services/api/app/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry helpers."""
+
+from app.telemetry.otel import configure_telemetry
+
+__all__ = ["configure_telemetry"]

--- a/services/api/app/telemetry/otel.py
+++ b/services/api/app/telemetry/otel.py
@@ -1,0 +1,32 @@
+"""OpenTelemetry integration helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+if TYPE_CHECKING:
+    from app.config import Settings
+
+
+def configure_telemetry(app: FastAPI, settings: "Settings") -> None:
+    """Configure OpenTelemetry exporters and instrumentation."""
+    if not settings.otel_exporter_otlp_endpoint:
+        return
+
+    resource = Resource.create({"service.name": "ai-pm-api"})
+    provider = TracerProvider(resource=resource)
+    span_processor = BatchSpanProcessor(
+        OTLPSpanExporter(endpoint=settings.otel_exporter_otlp_endpoint)
+    )
+    provider.add_span_processor(span_processor)
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor().instrument_app(app)

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -3,15 +3,29 @@ name = "ai-pm-api"
 version = "0.1.0"
 description = "FastAPI service for the ai-pm platform"
 authors = ["ai-pm Platform <dev@example.com>"]
-packages = []
+packages = [{ include = "app" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.110.0"
 uvicorn = { version = "^0.29.0", extras = ["standard"] }
+pydantic-settings = "^2.2.1"
+sqlalchemy = "^2.0.27"
+alembic = "^1.13.1"
+asyncpg = "^0.29.0"
+psycopg2-binary = "^2.9.9"
+httpx = "^0.27.0"
+opentelemetry-api = "^1.23.0"
+opentelemetry-sdk = "^1.23.0"
+opentelemetry-instrumentation-fastapi = "^0.44b0"
+opentelemetry-exporter-otlp = "^1.23.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.0.0"
+pytest = "^8.1.1"
+pytest-asyncio = "^0.23.5"
+
+[tool.poetry.scripts]
+uvicorn = "uvicorn.main:main"
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]

--- a/services/api/tests/test_health.py
+++ b/services/api/tests/test_health.py
@@ -1,0 +1,22 @@
+import pytest
+from httpx import AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_healthz() -> None:
+    async with AsyncClient(app=app, base_url="http://testserver") as client:
+        response = await client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_ping() -> None:
+    async with AsyncClient(app=app, base_url="http://testserver") as client:
+        response = await client.get("/v1/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- scaffold a FastAPI application package with routing, configuration, telemetry hooks, and health checks
- add SQLAlchemy base, placeholder models, and Alembic initialization including configuration and empty migration
- provide pytest coverage for health endpoints and a Dockerfile for containerized deployment

## Testing
- poetry install --no-root *(fails: no internet access in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bc01ad5c8324a28b1c69bb42d29e