### PR TITLE
Add Temporal worker service scaffold

### DIFF
--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV POETRY_HOME=/opt/poetry \
+    POETRY_VIRTUALENVS_CREATE=false \
+    PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir "poetry==2.2.1"
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+
+RUN poetry install --only main --no-interaction --no-ansi
+
+COPY worker ./worker
+COPY run_worker.py ./
+
+CMD ["poetry", "run", "python", "run_worker.py"]

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -1,17 +1,23 @@
 [tool.poetry]
-name = "ai-pm-worker"
+name = "worker"
 version = "0.1.0"
-description = "Temporal worker service for the ai-pm platform"
-authors = ["ai-pm Platform <dev@example.com>"]
-packages = []
+description = "Temporal worker service"
+authors = ["AI PM Team <team@example.com>"]
+packages = [{ include = "worker" }]
 
 [tool.poetry.dependencies]
-python = "^3.11"
-temporalio = "^1.5.0"
+python = ">=3.11,<3.13"
+temporalio = "^1.7.0"
+pydantic-settings = "^2.5.2"
+opentelemetry-api = "^1.28.2"
+opentelemetry-sdk = "^1.28.2"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.0.0"
+pytest = "^8.3.0"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
 
 [build-system]
-requires = ["poetry-core>=1.6.0"]
+requires = ["poetry-core>=1.7.0"]
 build-backend = "poetry.core.masonry.api"

--- a/services/worker/run_worker.py
+++ b/services/worker/run_worker.py
@@ -1,0 +1,36 @@
+"""Entry point for running the Temporal worker."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from worker.activities import echo_activity
+from worker.settings import settings
+from worker.workflows import EchoWorkflow
+
+TASK_QUEUE = "ai-pm-default"
+
+
+async def main() -> None:
+    """Start the Temporal worker."""
+
+    client = await Client.connect(settings.host, namespace=settings.namespace)
+
+    worker = Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[EchoWorkflow],
+        activities=[echo_activity],
+    )
+
+    logging.info("Starting worker on task queue '%s'", TASK_QUEUE)
+    await worker.run()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/services/worker/tests/test_demo_workflow.py
+++ b/services/worker/tests/test_demo_workflow.py
@@ -1,0 +1,33 @@
+"""Tests for the demo workflow."""
+
+from __future__ import annotations
+
+import asyncio
+
+from temporalio.testing import WorkflowEnvironment
+
+from worker.activities import echo_activity
+from worker.workflows import EchoWorkflow
+
+
+async def _run_demo_workflow() -> None:
+    env = await WorkflowEnvironment.start_time_skipping()
+    async with env:
+        await env.start_worker(
+            task_queue="ai-pm-default",
+            workflows=[EchoWorkflow],
+            activities=[echo_activity],
+        )
+
+        result = await env.client.execute_workflow(
+            EchoWorkflow.run,
+            "hello world",
+            id="demo-workflow",
+            task_queue="ai-pm-default",
+        )
+
+        assert result == "hello world"
+
+
+def test_demo_workflow() -> None:
+    asyncio.run(_run_demo_workflow())

--- a/services/worker/worker/__init__.py
+++ b/services/worker/worker/__init__.py
@@ -1,0 +1,3 @@
+"""Temporal worker package."""
+
+__all__ = ["settings"]

--- a/services/worker/worker/activities/__init__.py
+++ b/services/worker/worker/activities/__init__.py
@@ -1,0 +1,5 @@
+"""Activity definitions."""
+
+from .demo_activity import echo_activity
+
+__all__ = ["echo_activity"]

--- a/services/worker/worker/activities/demo_activity.py
+++ b/services/worker/worker/activities/demo_activity.py
@@ -1,0 +1,9 @@
+"""Demo activity implementations."""
+
+from __future__ import annotations
+
+
+async def echo_activity(message: str) -> str:
+    """Return the provided message."""
+
+    return message

--- a/services/worker/worker/settings.py
+++ b/services/worker/worker/settings.py
@@ -1,0 +1,17 @@
+"""Runtime configuration for the Temporal worker service."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    host: str = "localhost:7233"
+    namespace: str = "default"
+
+    model_config = SettingsConfigDict(env_prefix="TEMPORAL_", case_sensitive=False)
+
+
+settings = Settings()
+
+__all__ = ["Settings", "settings"]

--- a/services/worker/worker/workflows/__init__.py
+++ b/services/worker/worker/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow definitions."""
+
+from .demo_workflow import EchoWorkflow
+
+__all__ = ["EchoWorkflow"]

--- a/services/worker/worker/workflows/demo_workflow.py
+++ b/services/worker/worker/workflows/demo_workflow.py
@@ -1,0 +1,24 @@
+"""Demo workflow that echoes a message via an activity."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+from worker.activities.demo_activity import echo_activity
+
+
+@workflow.defn
+class EchoWorkflow:
+    """A simple workflow that echoes messages."""
+
+    @workflow.run
+    async def run(self, message: str) -> str:
+        """Execute the workflow and return the echoed message."""
+
+        return await workflow.execute_activity(
+            echo_activity,
+            message,
+            schedule_to_close_timeout=timedelta(seconds=10),
+        )


### PR DESCRIPTION
## Summary
- scaffold the Temporal worker service with Poetry configuration and Dockerfile
- add demo echo workflow/activity pair with worker entrypoint tied to the default task queue
- cover the workflow with a Temporal test-harness based unit test

## Testing
- `poetry install --with dev` *(fails: All attempts to connect to pypi.org failed in the offline environment)*
- `poetry run pytest` *(fails: Temporal test server download requires internet access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5be81f10c8324b8e0f2043c6e5997